### PR TITLE
Tighten stanford.edu filter

### DIFF
--- a/assets/blacklist.json
+++ b/assets/blacklist.json
@@ -4908,7 +4908,7 @@
 		"*://*.standardmedia.co.ke/*",
 		"*://*.standardnewswire.com/*",
 		"*://*.standardspeaker.com/*",
-		"*://*.stanford.edu/*",
+		"*://*.stanford.edu/news/*",
 		"*://*.stanforddaily.com/*",
 		"*://*.staradvertiser.com/*",
 		"*://*.starafrica.com/*",


### PR DESCRIPTION
The entire Stanford University website (stanford.edu) is blocked, including genuinely non-news content such as [this whitepaper](http://cs242.stanford.edu/assets/projects/2017/parastoo-gdietz44.pdf). This seems like overkill. 

After browsing the site a bit, I was able to identify news content under `news.stanford.edu/*` (already blocked) and `*.stanford.edu/news/*` (added in this PR).